### PR TITLE
 Updated ICARTT Read/Combine Utilities for MONET 

### DIFF
--- a/monet/models/__init__.py
+++ b/monet/models/__init__.py
@@ -1,5 +1,5 @@
-from . import cmaq, hysplit, camx
+from . import cmaq, hysplit, camx, combinetool
 
-__all__ = ['cmaq', 'hysplit', 'camx']
+__all__ = ['cmaq', 'hysplit', 'camx', 'combinetool']
 
 __name__ = 'models'

--- a/monet/models/combinetool.py
+++ b/monet/models/combinetool.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, print_function
 
-from pandas import Series
+from pandas import Series, merge_asof
 
 # from ..util import interp_util as interpo
 # from ..obs import epa_util
@@ -108,6 +108,75 @@ def combine_da_to_df_xesmf(da, df, col=None, **kwargs):
     final_df = df.merge(
         df_interped, on=['latitude', 'longitude', 'time'], how='left')
     return final_df
+
+def combine_da_to_df_xesmf_strat(da, daz, df, **kwargs):
+    """This function will combine an xarray data array with spatial information
+    point observations in `df`.
+
+    Parameters
+    ----------
+    da : xr.DataArray
+        Description of parameter `da`.
+    daz : xr.DataArray
+        Description of parameter `daz`.
+    df : pd.DataFrame
+        Description of parameter `df`.
+    lay : iterable, default = [0]
+        Description of parameter `lay`.
+    radius : integer or float, default = 12e3
+        Description of parameter `radius`.
+
+    Returns
+    -------
+    pandas.DataFrame
+    """
+    from ..util.interp_util import constant_1d_xesmf
+    from ..util.resample import resample_xesmf
+   
+    try:
+        if da.shape != daz.shape:
+            raise RuntimeError
+    except RuntimeError:
+        print('da and daz must be of the same shape')
+        print('da shape= ',da.shape, 'daz shape= ',daz.shape)
+        return -1
+    
+    target = constant_1d_xesmf(
+        longitude=df.longitude.values, latitude=df.latitude.values)
+
+    da = _rename_latlon(da)  # check to rename 'latitude' and 'longitude' for xe.Regridder
+    daz= _rename_latlon(daz)
+    da_interped = resample_xesmf(da, target, **kwargs) #interpolate fields
+    daz_interped = resample_xesmf(daz, target, **kwargs)
+    da_interped = _rename_latlon(da_interped)  # check to change 'lat' 'lon' back 
+    daz_interped = _rename_latlon(daz_interped)  
+    
+
+    #sort aircraft target altitudes and call stratfiy from resample to do vertical interpolation
+    #resample_stratify from monet accessor
+    daz_interped_xyz = daz_interped.monet.stratify(sorted(df['altitude']), daz_interped, axis=1)
+    da_interped_xyz = da_interped.monet.stratify(sorted(df['altitude']), daz_interped, axis=1)
+    da_interped_xyz.name = da.name
+    daz_interped_xyz.name = 'altitude'
+    df_interped_xyz = da_interped_xyz.to_dataframe().reset_index()
+    dfz_interped_xyz =daz_interped_xyz.to_dataframe().reset_index()
+    
+    df_interped_xyz.insert(0,'altitude',dfz_interped_xyz['altitude'], allow_duplicates=True)
+    
+ 
+    cols = Series(df_interped_xyz.columns)
+    drop_cols = cols.loc[cols.isin(['x', 'y', 'z'])]
+    df_interped_xyz.drop(drop_cols, axis=1, inplace=True)
+    if da.name in df.columns:
+        df_interped_xyz.rename(columns={da.name: da.name + '_new'}, inplace=True)
+        print(df_interped_xyz.keys())
+   
+    final_df = merge_asof(df,df_interped_xyz,
+                             by=['latitude','longitude','altitude'],
+                             on = 'time',
+                             direction='nearest') 
+    return final_df
+
 
 
 def combine_da_to_height_profile(da, dset, radius_of_influence=12e3):

--- a/monet/obs/__init__.py
+++ b/monet/obs/__init__.py
@@ -1,11 +1,11 @@
 from __future__ import absolute_import, print_function
 from . import aeronet_mod, airnow_mod, aqs_mod, crn_mod, epa_util, improve_mod
-from . import ish_mod, tolnet_mod, cems_mod, nadp_mod, modis_swath
+from . import ish_mod, tolnet_mod, cems_mod, nadp_mod, modis_swath, icartt_mod
 
 __all__ = [
     'aeronet_mod', 'airnow_mod', 'aqs_mod', 'crn_mod', 'epa_util',
     'improve_mod', 'ish_mod', 'tolnet_mod', 'cems_mod', 'nadp_mod',
-    'modis_swath'
+    'modis_swath', 'icartt_mod'
 ]
 
 __name__ = 'obs'
@@ -19,4 +19,4 @@ improve = improve_mod.IMPROVE()
 tolnet = tolnet_mod.TOLNet()
 cems = cems_mod.CEMS()
 nadp = nadp_mod.NADP()
-
+icartt = icartt_mod.icartt()

--- a/monet/obs/icartt_mod.py
+++ b/monet/obs/icartt_mod.py
@@ -1,0 +1,85 @@
+""" This module opens data from the ICARTT format and reformats it for use in
+MONET. The module makes use of Barron Henderson's PseudoNetCDF
+(https://github.com/barronh/pseudonetcdf)and xarray to read the data.  It is
+noti ntended to read more than ONE file at a time """
+
+import xarray as xr
+import os
+import pandas as pd   
+
+
+class icartt(object):
+    """Short summary.
+    Reads icartt data file format and gets/reformats 4D coordinate data used
+    to manipulate/analyze and/or combine with model data later
+    """
+    def __init__(self):
+        self.objtype = 'ICARTT'
+        self.cwd = os.getcwd()
+        self.dset = None
+        
+        
+    
+    def add_data(self,fname):
+        """ This assumes that you have downloaded the specific ICARTT flight data
+        Xarray Open/Read the ICARTT flight dataset as pseudonetcdf
+        
+        
+        """  
+        #Xarray Open/Read the ICARTT flight dataset as pseudonetcdf engine
+        self.dset = xr.open_dataset(fname,engine='pseudonetcdf',decode_times=False)
+        return self.dset
+    
+    def get_data(self,da, lat_label=None, lon_label=None, alt_label=None):
+        """ Comes in as an xarray from add_xarray_Data
+        Allows for searching or user specified Lat/Lon variable names
+        Sets latitude and longitude as coordinates 
+        Reads start date and seconds elapsed, converts time coordinate
+        """  
+        possible_lats = ['Lat', 'Latitude', 'lat', 'latitude', 'Latitude_Deg', 
+        'Latitude_deg','Lat_deg', 'Lat_degree', 'Lat_Degree',
+        'Latitude_degrees','Latitude_Degrees', 'Latitude_degree', 
+        'Latitude_Degree', 'Lat_aircraft','Latitude_aircraft'
+        ]
+        possible_lons = ['Lon', 'Longitude', 'lon', 'longitude', 
+        'Longitude_Deg', 'Longitude_deg','Lon_deg', 'Lon_degree', 'Lon_Degree',
+        'Long', 'Long_Deg', 'Longitude_degrees', 'Longitude_Degrees', 
+        'Longitude_degree','Latitude_Degree','Lon_aircraft', 'Long_aircraft' 
+        'Longitude_aircraft'
+        ]
+        
+        #Get the unknown lat/lon variable names data along flight path
+        if lat_label is None and lon_label is None:
+            #   Change to dataframe to search the columns for possible lat lons
+            dfset = da.to_dataframe()
+            dfset['latitude'] = dfset[dfset.columns[dfset.columns.isin(possible_lats)]]
+            dfset['longitude'] = dfset[dfset.columns[dfset.columns.isin(possible_lons)]]
+            #   Place latitude/longitude back into xarray 
+            da['latitude'] = dfset['latitude']
+            da['longitude'] = dfset['longitude']
+        else:            
+            da['latitude'] = da[lat_label]
+            da['longitude'] = da[lon_label]
+        
+            
+        #Set laititude and longitude as x-y coordinates for the file
+        da.coords['latitude'] = da['latitude']
+        da.coords['longitude'] = da['longitude']
+        
+        #Change main 1D dimension name from POINTS to time for easier resampling
+        da = da.rename({'POINTS': 'time'},inplace=True) 
+        
+         #Convert time from start date and TFLAG in UT seconds from midnight
+        da['time'] = pd.to_datetime(da.SDATE.replace(', ', '-')) + pd.to_timedelta(da[da.TFLAG],unit='s')        
+        
+        #If user sets the specified altitude label it will be a coordinate
+        if alt_label is None:
+            print('No alt_label provided...nothing added as z-coordinate (will result in vert_interp error)')
+        else:
+            #Set specified 'altitude' as z coordinates for the file
+            da.coords['altitude'] = da[alt_label]
+        df = da.to_dataframe().reset_index()  
+        return df
+    
+    
+        

--- a/monet/obs/icartt_mod.py
+++ b/monet/obs/icartt_mod.py
@@ -5,7 +5,7 @@ noti ntended to read more than ONE file at a time """
 
 import xarray as xr
 import os
-import pandas as pd   
+import pandas as pd
 
 
 class icartt(object):
@@ -13,73 +13,73 @@ class icartt(object):
     Reads icartt data file format and gets/reformats 4D coordinate data used
     to manipulate/analyze and/or combine with model data later
     """
+
     def __init__(self):
         self.objtype = 'ICARTT'
         self.cwd = os.getcwd()
         self.dset = None
-        
-        
-    
-    def add_data(self,fname):
+
+    def add_data(self, fname):
         """ This assumes that you have downloaded the specific ICARTT flight data
         Xarray Open/Read the ICARTT flight dataset as pseudonetcdf
-        
-        
-        """  
-        #Xarray Open/Read the ICARTT flight dataset as pseudonetcdf engine
-        self.dset = xr.open_dataset(fname,engine='pseudonetcdf',decode_times=False)
+
+
+        """
+        # Xarray Open/Read the ICARTT flight dataset as pseudonetcdf engine
+        self.dset = xr.open_dataset(
+            fname, engine='pseudonetcdf', decode_times=False)
         return self.dset
-    
-    def get_data(self,da, lat_label=None, lon_label=None, alt_label=None):
+
+    def get_data(self, da, lat_label=None, lon_label=None, alt_label=None):
         """ Comes in as an xarray from add_xarray_Data
         Allows for searching or user specified Lat/Lon variable names
         Sets latitude and longitude as coordinates 
         Reads start date and seconds elapsed, converts time coordinate
-        """  
-        possible_lats = ['Lat', 'Latitude', 'lat', 'latitude', 'Latitude_Deg', 
-        'Latitude_deg','Lat_deg', 'Lat_degree', 'Lat_Degree',
-        'Latitude_degrees','Latitude_Degrees', 'Latitude_degree', 
-        'Latitude_Degree', 'Lat_aircraft','Latitude_aircraft'
-        ]
-        possible_lons = ['Lon', 'Longitude', 'lon', 'longitude', 
-        'Longitude_Deg', 'Longitude_deg','Lon_deg', 'Lon_degree', 'Lon_Degree',
-        'Long', 'Long_Deg', 'Longitude_degrees', 'Longitude_Degrees', 
-        'Longitude_degree','Latitude_Degree','Lon_aircraft', 'Long_aircraft' 
-        'Longitude_aircraft'
-        ]
-        
-        #Get the unknown lat/lon variable names data along flight path
+        """
+        possible_lats = ['Lat', 'Latitude', 'lat', 'latitude', 'Latitude_Deg',
+                         'Latitude_deg', 'Lat_deg', 'Lat_degree', 'Lat_Degree',
+                         'Latitude_degrees', 'Latitude_Degrees', 'Latitude_degree',
+                         'Latitude_Degree', 'Lat_aircraft', 'Latitude_aircraft'
+                         ]
+        possible_lons = ['Lon', 'Longitude', 'lon', 'longitude',
+                         'Longitude_Deg', 'Longitude_deg', 'Lon_deg', 'Lon_degree', 'Lon_Degree',
+                         'Long', 'Long_Deg', 'Longitude_degrees', 'Longitude_Degrees',
+                         'Longitude_degree', 'Latitude_Degree', 'Lon_aircraft', 'Long_aircraft'
+                         'Longitude_aircraft'
+                         ]
+
+        # Get the unknown lat/lon variable names data along flight path
         if lat_label is None and lon_label is None:
             #   Change to dataframe to search the columns for possible lat lons
             dfset = da.to_dataframe()
-            dfset['latitude'] = dfset[dfset.columns[dfset.columns.isin(possible_lats)]]
-            dfset['longitude'] = dfset[dfset.columns[dfset.columns.isin(possible_lons)]]
-            #   Place latitude/longitude back into xarray 
+            dfset['latitude'] = dfset[dfset.columns[dfset.columns.isin(
+                possible_lats)]]
+            dfset['longitude'] = dfset[dfset.columns[dfset.columns.isin(
+                possible_lons)]]
+            #   Place latitude/longitude back into xarray
             da['latitude'] = dfset['latitude']
             da['longitude'] = dfset['longitude']
-        else:            
+        else:
             da['latitude'] = da[lat_label]
             da['longitude'] = da[lon_label]
-        
-            
-        #Set laititude and longitude as x-y coordinates for the file
+
+        # Set laititude and longitude as x-y coordinates for the file
         da.coords['latitude'] = da['latitude']
         da.coords['longitude'] = da['longitude']
-        
-        #Change main 1D dimension name from POINTS to time for easier resampling
-        da = da.rename({'POINTS': 'time'},inplace=True) 
-        
-         #Convert time from start date and TFLAG in UT seconds from midnight
-        da['time'] = pd.to_datetime(da.SDATE.replace(', ', '-')) + pd.to_timedelta(da[da.TFLAG],unit='s')        
-        
-        #If user sets the specified altitude label it will be a coordinate
+
+        # Change main 1D dimension name from POINTS to time for easier resampling
+        da = da.rename({'POINTS': 'time'}, inplace=True)
+
+        # Convert time from start date and TFLAG in UT seconds from midnight
+        da['time'] = pd.to_datetime(da.SDATE.replace(
+            ', ', '-')) + pd.to_timedelta(da[da.TFLAG], unit='s')
+
+        # If user sets the specified altitude label it will be a coordinate
         if alt_label is None:
-            print('No alt_label provided...nothing added as z-coordinate (will result in vert_interp error)')
+            print(
+                'No alt_label provided...nothing added as z-coordinate (will result in vert_interp error)')
         else:
-            #Set specified 'altitude' as z coordinates for the file
+            # Set specified 'altitude' as z coordinates for the file
             da.coords['altitude'] = da[alt_label]
-        df = da.to_dataframe().reset_index()  
+        df = da.to_dataframe().reset_index()
         return df
-    
-    
-        

--- a/monet/util/resample.py
+++ b/monet/util/resample.py
@@ -92,7 +92,8 @@ def resample_stratify(da, levels, vertical, axis=1):
     out.attrs = da.attrs.copy()
     if len(da.coords) > 0:
         for i in da.coords:
-            out.coords[i] = da.coords[i]
+            if i != 'z':
+                out.coords[i] = da.coords[i]
     return out
 
 

--- a/test_icartt.py
+++ b/test_icartt.py
@@ -1,0 +1,85 @@
+#!/data/aqf2/barryb/anaconda2/envs/patrick_monet/bin/python
+"""
+Created on Fri Sep 28 11:41:46 2018
+
+@author: Patrick Campbell
+"""
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+from matplotlib import cm
+from mpl_toolkits.mplot3d import Axes3D
+import monet
+from monet.obs import icartt
+from monet.models import cmaq, combinetool
+import seaborn as sns
+
+obsname = '/data/aqf/patrickc/data/OWLETS_2018/OWLETS2018_UMDAircraft_RF1_20180617_R0.ict'
+modname = '/data/aqf/patrickc/models/NAQFC/tests/aqm.20180617.t12z.cgrid.ncf'
+modnamez = '/data/aqf/patrickc/models/NAQFC/tests/aqm.t12z.metcro3d.ncf'
+
+
+#Read ICARTT data file and add data as xarray
+dataread = icartt.add_data(obsname)
+
+#Get flight 'time', 'latitude', and 'longitude', and specified 'altitude' (if specified)
+obs_df = icartt.get_data(dataread,lat_label=None, lon_label=None,
+                      alt_label='ALTGPS_m')
+
+#get 3D CTM model data to analyze
+mod_da = cmaq.open_dataset(modname)
+#get 3D CTM model data that includes model layer heights (AGL) to interpolate
+#The example below shows for CMAQ using mid-layer height above ground ---mod_da and mod_daz must be of same shape
+mod_daz = cmaq.open_dataset(modnamez)
+#Set model variable and vertical height fields for interpolation of passed data arrays
+col = 'O3'
+colz = 'ZH'  
+
+#Combines model and interpolated flight data both horizontally and vertically
+#df_test = combinetool.combine_mod_to_flight_data(obs,
+#                                                 mod,
+#                                                 modzvar,
+#                                                 obsvar='O3_ppbv',
+#                                                 modvar='O3',
+#                                                 resample = False,
+#                                                 freq = '60S',
+#                                                 )
+
+df_test  = combinetool.combine_da_to_df_xesmf_strat(mod_da[col], mod_daz[colz][0:4,:,:,:], obs_df, method='bilinear',reuse_weights=True)
+#fills missing values, -9999, with NaN
+df_test_fill=df_test.replace(-9999,np.NaN)
+#write to csv to check
+df_test_fill.to_csv('df_out_'+col+'.csv')
+
+#set plotting context
+sns.set_context('paper')
+
+#Simple O3 Line Analysis plot
+plt.figure()
+plt.xlabel('time (UTC)')
+plt.ylabel('O3 (ppbv)')
+plt.plot( 'time', 'O3',       data=df_test_fill, marker='', color='olive', linewidth=2, linestyle='solid', label="model")
+plt.plot( 'time', 'O3_ppbv', data=df_test_fill, marker='', color='blue', linewidth=2, linestyle='solid', label="observed")
+plt.legend()
+plt.ylim(40, 90)
+#More sophisticated 3D O3 contour plot:
+df_diff = df_test_fill['O3'] - df_test_fill['O3_ppbv']  #take mod-obs difference
+fig = plt.figure()
+ax = fig.gca(projection='3d')
+ax.scatter3D(df_test_fill['longitude'], df_test_fill['latitude'], df_test_fill['altitude'],c=df_diff, cmap=cm.coolwarm)
+ax.set_title('Mod-Obs O3 Difference (ppbv)')
+ax.set_xlabel('longitude',rotation=150)
+ax.set_ylabel('latitude')
+ax.set_zlabel('altitude (m)', rotation=60)
+ax.scatter3D(df_test_fill['longitude'], df_test_fill['latitude'], df_test_fill['altitude'],c=df_diff, cmap=cm.coolwarm)
+fig, ax = plt.subplots() #get label bar
+cax = ax.imshow(np.expand_dims(df_diff,axis=1), interpolation='nearest', cmap=cm.coolwarm)
+cbar = fig.colorbar(cax, orientation='vertical')
+
+
+
+#df_test.plot(x='time',y=col,kind='line')
+#plt.show()
+#df_test.plot(x='time',y='O3_ppbv',kind='line')
+#plt.show()
+#df_test.plot(x='O3_ppb',y=col,kind='line')
+#plt.show()

--- a/test_icartt.py
+++ b/test_icartt.py
@@ -18,24 +18,24 @@ modname = '/data/aqf/patrickc/models/NAQFC/tests/aqm.20180617.t12z.cgrid.ncf'
 modnamez = '/data/aqf/patrickc/models/NAQFC/tests/aqm.t12z.metcro3d.ncf'
 
 
-#Read ICARTT data file and add data as xarray
+# Read ICARTT data file and add data as xarray
 dataread = icartt.add_data(obsname)
 
-#Get flight 'time', 'latitude', and 'longitude', and specified 'altitude' (if specified)
-obs_df = icartt.get_data(dataread,lat_label=None, lon_label=None,
-                      alt_label='ALTGPS_m')
+# Get flight 'time', 'latitude', and 'longitude', and specified 'altitude' (if specified)
+obs_df = icartt.get_data(dataread, lat_label=None, lon_label=None,
+                         alt_label='ALTGPS_m')
 
-#get 3D CTM model data to analyze
+# get 3D CTM model data to analyze
 mod_da = cmaq.open_dataset(modname)
-#get 3D CTM model data that includes model layer heights (AGL) to interpolate
-#The example below shows for CMAQ using mid-layer height above ground ---mod_da and mod_daz must be of same shape
+# get 3D CTM model data that includes model layer heights (AGL) to interpolate
+# The example below shows for CMAQ using mid-layer height above ground ---mod_da and mod_daz must be of same shape
 mod_daz = cmaq.open_dataset(modnamez)
-#Set model variable and vertical height fields for interpolation of passed data arrays
+# Set model variable and vertical height fields for interpolation of passed data arrays
 col = 'O3'
-colz = 'ZH'  
+colz = 'ZH'
 
-#Combines model and interpolated flight data both horizontally and vertically
-#df_test = combinetool.combine_mod_to_flight_data(obs,
+# Combines model and interpolated flight data both horizontally and vertically
+# df_test = combinetool.combine_mod_to_flight_data(obs,
 #                                                 mod,
 #                                                 modzvar,
 #                                                 obsvar='O3_ppbv',
@@ -44,42 +44,48 @@ colz = 'ZH'
 #                                                 freq = '60S',
 #                                                 )
 
-df_test  = combinetool.combine_da_to_df_xesmf_strat(mod_da[col], mod_daz[colz][0:4,:,:,:], obs_df, method='bilinear',reuse_weights=True)
-#fills missing values, -9999, with NaN
-df_test_fill=df_test.replace(-9999,np.NaN)
-#write to csv to check
-df_test_fill.to_csv('df_out_'+col+'.csv')
+df_test = combinetool.combine_da_to_df_xesmf_strat(
+    mod_da[col], mod_daz[colz][0:4, :, :, :], obs_df, method='bilinear', reuse_weights=True)
+# fills missing values, -9999, with NaN
+df_test_fill = df_test.replace(-9999, np.NaN)
+# write to csv to check
+df_test_fill.to_csv('df_out_' + col + '.csv')
 
-#set plotting context
+# set plotting context
 sns.set_context('paper')
 
-#Simple O3 Line Analysis plot
+# Simple O3 Line Analysis plot
 plt.figure()
 plt.xlabel('time (UTC)')
 plt.ylabel('O3 (ppbv)')
-plt.plot( 'time', 'O3',       data=df_test_fill, marker='', color='olive', linewidth=2, linestyle='solid', label="model")
-plt.plot( 'time', 'O3_ppbv', data=df_test_fill, marker='', color='blue', linewidth=2, linestyle='solid', label="observed")
+plt.plot('time', 'O3', data=df_test_fill, marker='', color='olive',
+         linewidth=2, linestyle='solid', label="model")
+plt.plot('time', 'O3_ppbv', data=df_test_fill, marker='', color='blue',
+         linewidth=2, linestyle='solid', label="observed")
 plt.legend()
 plt.ylim(40, 90)
-#More sophisticated 3D O3 contour plot:
-df_diff = df_test_fill['O3'] - df_test_fill['O3_ppbv']  #take mod-obs difference
+# More sophisticated 3D O3 contour plot:
+df_diff = df_test_fill['O3'] - \
+    df_test_fill['O3_ppbv']  # take mod-obs difference
 fig = plt.figure()
 ax = fig.gca(projection='3d')
-ax.scatter3D(df_test_fill['longitude'], df_test_fill['latitude'], df_test_fill['altitude'],c=df_diff, cmap=cm.coolwarm)
+ax.scatter3D(df_test_fill['longitude'], df_test_fill['latitude'],
+             df_test_fill['altitude'], c=df_diff, cmap=cm.coolwarm)
 ax.set_title('Mod-Obs O3 Difference (ppbv)')
-ax.set_xlabel('longitude',rotation=150)
+ax.set_xlabel('longitude', rotation=150)
 ax.set_ylabel('latitude')
 ax.set_zlabel('altitude (m)', rotation=60)
-ax.scatter3D(df_test_fill['longitude'], df_test_fill['latitude'], df_test_fill['altitude'],c=df_diff, cmap=cm.coolwarm)
-fig, ax = plt.subplots() #get label bar
-cax = ax.imshow(np.expand_dims(df_diff,axis=1), interpolation='nearest', cmap=cm.coolwarm)
+ax.scatter3D(df_test_fill['longitude'], df_test_fill['latitude'],
+             df_test_fill['altitude'], c=df_diff, cmap=cm.coolwarm)
+fig, ax = plt.subplots()  # get label bar
+cax = ax.imshow(np.expand_dims(df_diff, axis=1),
+                interpolation='nearest', cmap=cm.coolwarm)
 cbar = fig.colorbar(cax, orientation='vertical')
 
 
-
-#df_test.plot(x='time',y=col,kind='line')
-#plt.show()
-#df_test.plot(x='time',y='O3_ppbv',kind='line')
-#plt.show()
-#df_test.plot(x='O3_ppb',y=col,kind='line')
-#plt.show()
+# df_test.plot(x='time',y=col,kind='line')
+# plt.show()
+# df_test.plot(x='time',y='O3_ppbv',kind='line')
+# plt.show()
+# df_test.plot(x='O3_ppb',y=col,kind='line')
+# plt.show()


### PR DESCRIPTION
This updated pull request adds new python modules to read aircraft data from the ICARTT format and re-formats for use in MONET. The module makes use of xarray and pseudoNetCDF engine (https://github.com/barronh/pseudonetcdf) to read the data. It is not intended to read more than ONE file at a time.

This pull request also adds modules to both horizontally and vertically interpolate air quality/meteorological model grid data (e.g., CMAQ), and pair in time/space with the formatted ICARTT dataframe.

The new module requires 6 main inputs, 1) ICARTT formatted observation filename, 2) Gridded model filename with desired AQ/met variables, 3) Gridded model filename with desired model height variables, 4) - 5) associated geometric altitude label in ICARRT file and model vertical level heights in gridded file, and 6) associated gridded AQ/met variable to pair.

A test script (test_icartt.py) is included that describes required/optional inputs to the get/read and combine modules. A test output CSV file is written, and test plots are generated (examples shown here).

![o3_diff_3d_20180617](https://user-images.githubusercontent.com/26631222/48015490-45f49180-e0f7-11e8-8878-d247a6d4f9dc.png)
![o3_ts_20180617](https://user-images.githubusercontent.com/26631222/48015491-45f49180-e0f7-11e8-997c-aa8d174c3232.png)

The vertical interpolations and mod-obs dataframe merge may be slow when large differences in the model and observation sample time frequencies exist.  In this case, resampling the formatted dataframe (e.g., hourly) may be desired prior to combination (i.e., obs_df.resample('H').mean()).