### PR TITLE
aqs_mod.py

### DIFF
--- a/monet/obs/aqs_mod.py
+++ b/monet/obs/aqs_mod.py
@@ -51,13 +51,13 @@ class AQS(object):
         #        self.baseurl = 'https://aqs.epa.gov/aqsweb/airdata/'
         self.objtype = 'AQS'
         self.baseurl = 'https://aqs.epa.gov/aqsweb/airdata/'
-        #self.renamedhcols = [
+        # self.renamedhcols = [
         #    'time', 'time_local', 'state_code', 'county_code', 'site_num',
         #    'parameter_code', 'poc', 'latitude', 'longitude', 'datum',
         #    'parameter_name', 'obs', 'units', 'mdl', 'uncertainty',
         #    'qualifier', 'method_type', 'method_code', 'method_name',
         #    'state_name', 'county_name', 'date_of_last_change'
-        #]
+        # ]
         self.renameddcols = [
             'time_local', 'state_code', 'county_code', 'site_num',
             'parameter_code', 'poc', 'latitude', 'longitude', 'datum',
@@ -86,7 +86,7 @@ class AQS(object):
         columns : list of strings
                   list of current columns
         verbose : boolean
-       
+
         Returns
         --------
         rcolumn: list of strings
@@ -95,15 +95,16 @@ class AQS(object):
         rcolumn = []
         for ccc in columns:
             if ccc.strip() == 'Sample Measurement':
-               newc = 'obs'
+                newc = 'obs'
             elif ccc.strip() == 'Units of Measure':
-               newc='units'
-            else: 
-               newc = ccc.strip().lower()
-               newc = newc.replace(' ','_')
-            if verbose: print(ccc + ' renamed ' + newc)
+                newc = 'units'
+            else:
+                newc = ccc.strip().lower()
+                newc = newc.replace(' ', '_')
+            if verbose:
+                print(ccc + ' renamed ' + newc)
             rcolumn.append(newc)
-        return rcolumn     
+        return rcolumn
 
     def load_aqs_file(self, url, network):
         """Short summary.
@@ -148,7 +149,7 @@ class AQS(object):
                     'time_local': ["Date Local", "Time Local"]
                 },
                 infer_datetime_format=True)
-            #print(df.columns.values)
+            # print(df.columns.values)
             df.columns = self.columns_rename(df.columns.values)
 
         df['siteid'] = df.state_code.astype(str).str.zfill(
@@ -335,7 +336,6 @@ class AQS(object):
         dff = dd.from_delayed(dfs)
         dfff = dff.compute()
         return(self.add_data2(dfff, daily, network))
-        
 
     def add_data2(self, df, daily=False, network=None):
         """
@@ -344,7 +344,7 @@ class AQS(object):
         df : dataframe
         daily : boolean
         network : 
-       
+
         Returns:
         self.df.copy() : dataframe 
         """

--- a/monet/obs/aqs_mod.py
+++ b/monet/obs/aqs_mod.py
@@ -51,13 +51,13 @@ class AQS(object):
         #        self.baseurl = 'https://aqs.epa.gov/aqsweb/airdata/'
         self.objtype = 'AQS'
         self.baseurl = 'https://aqs.epa.gov/aqsweb/airdata/'
-        self.renamedhcols = [
-            'time_local', 'time', 'state_code', 'county_code', 'site_num',
-            'parameter_code', 'poc', 'latitude', 'longitude', 'datum',
-            'parameter_name', 'obs', 'units', 'mdl', 'uncertainty',
-            'qualifier', 'method_type', 'method_code', 'method_name',
-            'state_name', 'county_name', 'date_of_last_change'
-        ]
+        #self.renamedhcols = [
+        #    'time', 'time_local', 'state_code', 'county_code', 'site_num',
+        #    'parameter_code', 'poc', 'latitude', 'longitude', 'datum',
+        #    'parameter_name', 'obs', 'units', 'mdl', 'uncertainty',
+        #    'qualifier', 'method_type', 'method_code', 'method_name',
+        #    'state_name', 'county_name', 'date_of_last_change'
+        #]
         self.renameddcols = [
             'time_local', 'state_code', 'county_code', 'site_num',
             'parameter_code', 'poc', 'latitude', 'longitude', 'datum',
@@ -77,6 +77,33 @@ class AQS(object):
         self.monitor_df = None
         self.daily = False
         self.d_df = None  # daily dataframe
+
+    def columns_rename(self, columns, verbose=False):
+        """
+        rename columns for hourly data. 
+        Parameters
+        ----------
+        columns : list of strings
+                  list of current columns
+        verbose : boolean
+       
+        Returns
+        --------
+        rcolumn: list of strings
+                 list of new column names to use.
+        """
+        rcolumn = []
+        for ccc in columns:
+            if ccc.strip() == 'Sample Measurement':
+               newc = 'obs'
+            elif ccc.strip() == 'Units of Measure':
+               newc='units'
+            else: 
+               newc = ccc.strip().lower()
+               newc = newc.replace(' ','_')
+            if verbose: print(ccc + ' renamed ' + newc)
+            rcolumn.append(newc)
+        return rcolumn     
 
     def load_aqs_file(self, url, network):
         """Short summary.
@@ -121,7 +148,8 @@ class AQS(object):
                     'time_local': ["Date Local", "Time Local"]
                 },
                 infer_datetime_format=True)
-            df.columns = self.renamedhcols
+            #print(df.columns.values)
+            df.columns = self.columns_rename(df.columns.values)
 
         df['siteid'] = df.state_code.astype(str).str.zfill(
             2) + df.county_code.astype(str).str.zfill(3) + df.site_num.astype(
@@ -245,7 +273,6 @@ class AQS(object):
 
         """
         import requests
-
         if not os.path.isfile(fname):
             print('\n Retrieving: ' + fname)
             print(url)
@@ -279,7 +306,7 @@ class AQS(object):
 
         Returns
         -------
-        type
+        pandas DataFrame
             Description of returned object.
 
         """
@@ -306,7 +333,22 @@ class AQS(object):
         else:
             dfs = [dask.delayed(self.load_aqs_file)(i, network) for i in urls]
         dff = dd.from_delayed(dfs)
-        self.df = dff.compute()
+        dfff = dff.compute()
+        return(self.add_data2(dfff, daily, network))
+        
+
+    def add_data2(self, df, daily=False, network=None):
+        """
+        Parameters
+        ------------
+        df : dataframe
+        daily : boolean
+        network : 
+       
+        Returns:
+        self.df.copy() : dataframe 
+        """
+        self.df = df
         self.df = self.change_units(self.df)
         if self.monitor_df is None:
             self.monitor_df = read_monitor_file()


### PR DESCRIPTION
   fixed bug in which the time and time_local column were being switched in the dataframe generated by the AQS class when the columns were renamed in the load_aqs_file method.
   1. created a new method for renaming columns for the hourly data.
   2. broke the add_data method into two parts.
   add_data now loads the data and then calls add_data2 in order to process the data further.
   This facilitates testing of the code in add_data2 with a test csv file.