### PR TITLE
Fix failing xesmf remap test 

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -25,6 +25,3 @@ dependencies:
   - packaging
   - pooch
   - pytest
-  #
-  - esmf<8.4
-  - shapely<2

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -26,3 +26,4 @@ dependencies:
   - pooch
   - pytest
   - shapely<2
+  - esmf<8.4

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -25,5 +25,6 @@ dependencies:
   - packaging
   - pooch
   - pytest
-  - shapely<2
+  #
   - esmf<8.4
+  - shapely<2

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -25,3 +25,4 @@ dependencies:
   - packaging
   - pooch
   - pytest
+  - shapely<2

--- a/monet/monet_accessor.py
+++ b/monet/monet_accessor.py
@@ -1324,7 +1324,7 @@ class MONETAccessor:
             return _rename_to_monet_latlon(out)
 
         else:
-            print("xesmf unavailable. " "Try `import xesmf` and check the failure message.")
+            print("xesmf unavailable. Try `import xesmf` and check the failure message.")
 
     def combine_point(self, data, suffix=None, pyresample=True, **kwargs):
         """Short summary.
@@ -1480,7 +1480,7 @@ class MONETAccessorDataset:
                 # TODO: raise
 
         else:
-            print("xesmf unavailable. " "Try `import xesmf` and check the failure message.")
+            print("xesmf unavailable. Try `import xesmf` and check the failure message.")
 
     def _remap_xesmf_dataset(self, dset, filename="monet_xesmf_regrid_file.nc", **kwargs):
         skip_keys = ["lat", "lon", "time", "TFLAG"]

--- a/monet/monet_accessor.py
+++ b/monet/monet_accessor.py
@@ -1303,7 +1303,7 @@ class MONETAccessor:
 
         Parameters
         ----------
-        daaarray : ndarray or xarray DataArray
+        dataarray : ndarray or xarray DataArray
             Description of parameter `dset`.
         radius_of_influence : float or integer
             radius of influcence for pyresample in meters.
@@ -1322,6 +1322,9 @@ class MONETAccessor:
             source = _rename_latlon(dataarray)
             out = resample.resample_xesmf(source, target, method=method, **kwargs)
             return _rename_to_monet_latlon(out)
+
+        else:
+            print("xesmf unavailable. " "Try `import xesmf` and check the failure message.")
 
     def combine_point(self, data, suffix=None, pyresample=True, **kwargs):
         """Short summary.
@@ -1452,20 +1455,15 @@ class MONETAccessorDataset:
         return da
 
     def remap_xesmf(self, data, **kwargs):
-        """Resample the xesmf
+        """Resample using xESMF.
 
         Parameters
         ----------
-        data : type
-            Description of parameter `data`.
-        **kwargs : type
-            Description of parameter `**kwargs`.
-
-        Returns
-        -------
-        type
-            Description of returned object.
-
+        data : xarray.DataArray or xarray.Dataset
+            Data to be remapped.
+        **kwargs
+            Passed on to :func:`~monet.util.resample.resample_xesmf`
+            and then to ``xesmf.Regridder``.
         """
         if has_xesmf:
             try:
@@ -1480,6 +1478,9 @@ class MONETAccessorDataset:
             except TypeError:
                 print("data must be an xarray.DataArray or xarray.Dataset")
                 # TODO: raise
+
+        else:
+            print("xesmf unavailable. " "Try `import xesmf` and check the failure message.")
 
     def _remap_xesmf_dataset(self, dset, filename="monet_xesmf_regrid_file.nc", **kwargs):
         skip_keys = ["lat", "lon", "time", "TFLAG"]

--- a/monet/monet_accessor.py
+++ b/monet/monet_accessor.py
@@ -66,7 +66,7 @@ def _monet_to_latlon(da):
         dset = da.to_dataset()
     dset["x"] = da.longitude[0, :].values
     dset["y"] = da.latitude[:, 0].values
-    dset = dset.drop(["latitude", "longitude"])
+    dset = dset.drop_vars(["latitude", "longitude"])
     dset = dset.set_coords(["x", "y"])
     dset = dset.rename({"x": "lon", "y": "lat"})
     if isinstance(da, xr.DataArray):

--- a/tests/test_remap.py
+++ b/tests/test_remap.py
@@ -5,6 +5,10 @@ import xarray as xr
 import monet  # noqa: F401
 
 
+def test_import_xesmf():
+    import xesmf  # noqa: F401
+
+
 def test_remap_ds_ds():
     # Barry noted a problem with this
 


### PR DESCRIPTION
Resolves #118 and addresses xarray `.drop()` -> `.drop_vars()` warning.

* Constrain dev conda env so xesmf and the test work currently
* Add message so that failure of `.remap_xesmf` due to `xesmf` import failure isn't completely silent 