### PR TITLE
Fix `.monet.quick_contourf` e.g. for new RRFS domain

### DIFF
--- a/monet/monet_accessor.py
+++ b/monet/monet_accessor.py
@@ -1097,6 +1097,9 @@ class MONETAccessor:
 
         sns.set_context("notebook")
         da = _dataset_to_monet(self._obj)
+        dlon = da.longitude.diff("x")
+        if not ((dlon >= 0).all() or (dlon <= 0).all()):  # monotonic
+            da["longitude"] = da.longitude % 360  # unwrap longitudes
         crs_p = ccrs.PlateCarree()
         if "crs" not in map_kws:
             map_kws["crs"] = crs_p


### PR DESCRIPTION
In this domain, part of the upper left quadrant crosses 180 deg. longitude. Within `.monet.quick_contourf`, `wrap_longitudes` (to [-180, 180)) is applied, which gives unhelpful contour results:

![image](https://user-images.githubusercontent.com/15079414/222233049-a62a31b1-26c6-406a-8d3b-559ed1bcd072.png)

Masking that region, contourf has no problem:
![image](https://user-images.githubusercontent.com/15079414/222233595-401c375e-913e-4a39-a8f8-1150fd8d2bfc.png)

Solution: *un*wrap longitudes (to [0, 360)) before plotting if they aren't monotonic. Note that this doesn't seem to be needed for the other quick plot methods, which use imshow and pcolormesh.