### PR TITLE
Address a few warnings

### DIFF
--- a/monet/monet_accessor.py
+++ b/monet/monet_accessor.py
@@ -90,7 +90,7 @@ def _dataset_to_monet(dset, lat_name="latitude", lon_name="longitude", latlon2d=
             print("dset must be an xarray.DataArray or xarray.Dataset")
 
     if "south_north" in dset.dims:  # WRF WPS file
-        dset = dset.rename(dict(south_north="y", west_east="x"))
+        dset = dset.swap_dims(dict(south_north="y", west_east="x"))
         try:
             if isinstance(dset, xr.Dataset):
                 if "XLAT_M" in dset.data_vars:
@@ -194,7 +194,7 @@ def _coards_to_netcdf(dset, lat_name="lat", lon_name="lon"):
     lons, lats = meshgrid(lon, lat)
     x = arange(len(lon))
     y = arange(len(lat))
-    dset = dset.rename({lon_name: "x", lat_name: "y"})
+    dset = dset.swap_dims({lon_name: "x", lat_name: "y"})
     dset.coords["longitude"] = (("y", "x"), lons)
     dset.coords["latitude"] = (("y", "x"), lats)
     dset["x"] = x
@@ -223,7 +223,7 @@ def _dataarray_coards_to_netcdf(dset, lat_name="lat", lon_name="lon"):
     lons, lats = meshgrid(lon, lat)
     x = arange(len(lon))
     y = arange(len(lat))
-    dset = dset.rename({lon_name: "x", lat_name: "y"})
+    dset = dset.swap_dims({lon_name: "x", lat_name: "y"})
     dset.coords["latitude"] = (("y", "x"), lats)
     dset.coords["longitude"] = (("y", "x"), lons)
     dset["x"] = x
@@ -389,7 +389,7 @@ class MONETAccessorPandas:
             d = self._obj
         if d.index.name is not None:
             index_name = d.index.name
-        ds = d.to_xarray().rename({index_name: "x"}).expand_dims("y")
+        ds = d.to_xarray().swap_dims({index_name: "x"}).expand_dims("y")
         if "time" in ds.data_vars.keys():
             ds["time"] = ds.time.squeeze()  # it is only 1D
         if "latitude" in ds.data_vars.keys():

--- a/tests/test_remap.py
+++ b/tests/test_remap.py
@@ -95,7 +95,7 @@ def test_combine_da_da():
     new = combine_da_to_da(model, obs, merge=False, interp_time=False)
 
     # Check
-    assert new.dims == {"z": 5, "y": n, "x": n}
+    assert new.sizes == {"z": 5, "y": n, "x": n}
     assert float(new.longitude.min()) == pytest.approx(0.1)
     assert float(new.longitude.max()) == pytest.approx(0.9)
     assert float(new.latitude.min()) == pytest.approx(0.1)
@@ -105,6 +105,6 @@ def test_combine_da_da():
 
     # Use orthogonal selection to get track
     a = new.data.values[:, new.y, new.x]
-    assert a.shape == (model.dims["z"], n), "model levels but obs grid points"
+    assert a.shape == (model.sizes["z"], n), "model levels but obs grid points"
     assert (np.diff(a.mean(axis=0)) >= 0).all(), "obs profile goes S"
     assert np.isclose(np.diff(a.mean(axis=1)), 1, atol=1e-15, rtol=0).all(), "obs profile goes U"


### PR DESCRIPTION
These warnings:
```
tests/test_remap.py::test_combine_da_da
  /home/runner/work/monet/monet/monet/monet_accessor.py:197: UserWarning: rename 'longitude' to 'x' does not create an index anymore. Try using swap_dims instead or use set_index after rename to create an indexed coordinate.
    dset = dset.rename({lon_name: "x", lat_name: "y"})

tests/test_remap.py::test_combine_da_da
  /home/runner/work/monet/monet/monet/monet_accessor.py:197: UserWarning: rename 'latitude' to 'y' does not create an index anymore. Try using swap_dims instead or use set_index after rename to create an indexed coordinate.
    dset = dset.rename({lon_name: "x", lat_name: "y"})

tests/test_remap.py::test_combine_da_da
  /home/runner/work/monet/monet/tests/test_remap.py:98: FutureWarning: The return type of `Dataset.dims` will be changed to return a set of dimension names in future, in order to be more consistent with `DataArray.dims`. To access a mapping from dimension names to lengths, please use `Dataset.sizes`.
    assert new.dims == {"z": 5, "y": n, "x": n}

tests/test_remap.py::test_combine_da_da
  /home/runner/work/monet/monet/tests/test_remap.py:108: FutureWarning: The return type of `Dataset.dims` will be changed to return a set of dimension names in future, in order to be more consistent with `DataArray.dims`. To access a mapping from dimension names to lengths, please use `Dataset.sizes`.
    assert a.shape == (model.dims["z"], n), "model levels but obs grid points"
```