### PR TITLE
Longitude normalization

### DIFF
--- a/monet/monet_accessor.py
+++ b/monet/monet_accessor.py
@@ -1212,6 +1212,7 @@ class MONETAccessor:
 
         # from .grids import get_generic_projection_from_proj4
         # check to see if grid is supplied
+
         source_data = _dataset_to_monet(data)
         target_data = _dataset_to_monet(self._obj)
         source = self._get_CoordinateDefinition(data=source_data)
@@ -1525,16 +1526,7 @@ class MONETAccessorDataset:
 
         # from .grids import get_generic_projection_from_proj4
         # check to see if grid is supplied
-        try:
-            check_error = False
-            if isinstance(data, xr.DataArray) or isinstance(data, xr.Dataset):
-                check_error = False
-            else:
-                check_error = True
-            if check_error:
-                raise TypeError
-        except TypeError:
-            print("data must be either an Xarray.DataArray or Xarray.Dataset")
+
         source_data = _dataset_to_monet(data)
         target_data = _dataset_to_monet(self._obj)
         source = self._get_CoordinateDefinition(source_data)

--- a/monet/monet_accessor.py
+++ b/monet/monet_accessor.py
@@ -1190,7 +1190,7 @@ class MONETAccessor:
             g = geo.CoordinateDefinition(lats=self._obj.latitude, lons=self._obj.longitude)
         return g
 
-    def remap_nearest(self, data, **kwargs):
+    def remap_nearest(self, data, radius_of_influence=1e6, **kwargs):
         """Remap `data` from another grid to the current self grid using pyresample
         nearest-neighbor interpolation.
 
@@ -1215,9 +1215,11 @@ class MONETAccessor:
 
         source_data = _dataset_to_monet(data)
         target_data = _dataset_to_monet(self._obj)
-        source = self._get_CoordinateDefinition(data=source_data)
-        target = self._get_CoordinateDefinition(data=target_data)
-        r = kd_tree.XArrayResamplerNN(source, target, **kwargs)
+        source = self._get_CoordinateDefinition(source_data)
+        target = self._get_CoordinateDefinition(target_data)
+        r = kd_tree.XArrayResamplerNN(
+            source, target, radius_of_influence=radius_of_influence, **kwargs
+        )
         r.get_neighbour_info()
         if isinstance(source_data, xr.DataArray):
             result = r.get_sample_from_neighbour_info(source_data)
@@ -1505,7 +1507,7 @@ class MONETAccessorDataset:
             g = geo.CoordinateDefinition(lats=self._obj.latitude, lons=self._obj.longitude)
         return g
 
-    def remap_nearest(self, data, radius_of_influence=1e6):
+    def remap_nearest(self, data, radius_of_influence=1e6, **kwargs):
         """Remap `data` from another grid to the current self grid using pyresample
         nearest-neighbor interpolation.
 
@@ -1531,7 +1533,9 @@ class MONETAccessorDataset:
         target_data = _dataset_to_monet(self._obj)
         source = self._get_CoordinateDefinition(source_data)
         target = self._get_CoordinateDefinition(target_data)
-        r = kd_tree.XArrayResamplerNN(source, target, radius_of_influence=radius_of_influence)
+        r = kd_tree.XArrayResamplerNN(
+            source, target, radius_of_influence=radius_of_influence, **kwargs
+        )
         r.get_neighbour_info()
         if isinstance(source_data, xr.DataArray):
             result = r.get_sample_from_neighbour_info(source_data)

--- a/monet/monet_accessor.py
+++ b/monet/monet_accessor.py
@@ -62,7 +62,13 @@ def _monet_to_latlon(da):
         return dset
 
 
-def _dataset_to_monet(dset, lat_name="latitude", lon_name="longitude", latlon2d=False):
+def _dataset_to_monet(
+    dset,
+    lat_name="latitude",
+    lon_name="longitude",
+    latlon2d=False,
+    inplace=False,
+):
     """Rename xarray DataArray or Dataset coordinate variables for use with monet functions,
     returning a new xarray object.
 
@@ -77,6 +83,9 @@ def _dataset_to_monet(dset, lat_name="latitude", lon_name="longitude", latlon2d=
     latlon2d : bool
         Whether the latitude and longitude data is two-dimensional.
     """
+    if not inplace:
+        dset = dset.copy()
+
     if "grid_xt" in dset.dims:
         # GFS v16 file
         try:
@@ -123,10 +132,7 @@ def _dataset_to_monet(dset, lat_name="latitude", lon_name="longitude", latlon2d=
     else:
         dset = _rename_to_monet_latlon(dset)
         latlon2d = True
-        # print(len(dset[lat_name].shape))
-        # print(dset)
         if len(dset[lat_name].shape) < 2:
-            # print(dset[lat_name].shape)
             latlon2d = False
         if latlon2d is False:
             try:

--- a/monet/monet_accessor.py
+++ b/monet/monet_accessor.py
@@ -188,7 +188,7 @@ def _coards_to_netcdf(dset, lat_name="lat", lon_name="lon"):
     """
     from numpy import arange, meshgrid
 
-    lon = wrap_longitudes(dset[lon_name])
+    lon = dset[lon_name]
     lat = dset[lat_name]
     lons, lats = meshgrid(lon, lat)
     x = arange(len(lon))
@@ -217,7 +217,7 @@ def _dataarray_coards_to_netcdf(dset, lat_name="lat", lon_name="lon"):
     """
     from numpy import arange, meshgrid
 
-    lon = wrap_longitudes(dset[lon_name])
+    lon = dset[lon_name]
     lat = dset[lat_name]
     lons, lats = meshgrid(lon, lat)
     x = arange(len(lon))

--- a/monet/monet_accessor.py
+++ b/monet/monet_accessor.py
@@ -67,7 +67,6 @@ def _dataset_to_monet(
     lat_name="latitude",
     lon_name="longitude",
     latlon2d=False,
-    inplace=False,
 ):
     """Rename xarray DataArray or Dataset coordinate variables for use with monet functions,
     returning a new xarray object.
@@ -83,8 +82,6 @@ def _dataset_to_monet(
     latlon2d : bool
         Whether the latitude and longitude data is two-dimensional.
     """
-    if not inplace:
-        dset = dset.copy()
 
     if "grid_xt" in dset.dims:
         # GFS v16 file
@@ -177,7 +174,7 @@ def _rename_to_monet_latlon(ds):
     elif "XLAT" in check_list:
         return ds.rename({"XLAT": "latitude", "XLONG": "longitude"})
     else:
-        return ds
+        return ds.copy()
 
 
 def _coards_to_netcdf(dset, lat_name="lat", lon_name="lon"):

--- a/monet/monet_accessor.py
+++ b/monet/monet_accessor.py
@@ -119,7 +119,9 @@ def _dataset_to_monet(
 
     # Rename lat/lon coordinates to 'latitude'/'longitude'
     dset = _rename_to_monet_latlon(dset)  # common cases
-    if not {"latitude", "longitude"} <= set(dset.variables):
+    if (isinstance(dset, xr.Dataset) and not {"latitude", "longitude"} <= set(dset.variables)) or (
+        isinstance(dset, xr.DataArray) and not {"latitude", "longitude"} <= set(dset.coords)
+    ):
         dset = dset.rename({lat_name: "latitude", lon_name: "longitude"})
 
     # Maybe wrap longitudes

--- a/monet/monet_accessor.py
+++ b/monet/monet_accessor.py
@@ -1222,6 +1222,7 @@ class MONETAccessor:
             result = r.get_sample_from_neighbour_info(source_data)
             result.name = source_data.name
             result["latitude"] = target_data.latitude
+            result["longitude"] = target_data.longitude
 
         elif isinstance(source_data, xr.Dataset):
             results = {}
@@ -1544,6 +1545,7 @@ class MONETAccessorDataset:
             result = r.get_sample_from_neighbour_info(source_data)
             result.name = source_data.name
             result["latitude"] = target_data.latitude
+            result["longitude"] = target_data.longitude
 
         elif isinstance(source_data, xr.Dataset):
             results = {}

--- a/monet/monet_accessor.py
+++ b/monet/monet_accessor.py
@@ -89,42 +89,33 @@ def _dataset_to_monet(
         which can introduce small floating point errors, will be skipped.
         If unset (``None``), compute min/max to determine.
     """
+    if not isinstance(dset, (xr.DataArray, xr.Dataset)):
+        raise TypeError("dset must be an xarray.DataArray or xarray.Dataset")
 
-    if "grid_xt" in dset.dims:
-        # GFS v16 file
-        try:
-            if isinstance(dset, xr.DataArray):
-                dset = _dataarray_coards_to_netcdf(dset, lat_name="grid_yt", lon_name="grid_xt")
-            elif isinstance(dset, xr.Dataset):
-                dset = _dataarray_coards_to_netcdf(dset, lat_name="grid_yt", lon_name="grid_xt")
-            else:
-                raise ValueError
-        except ValueError:
-            print("dset must be an xarray.DataArray or xarray.Dataset")
+    if "grid_xt" in dset.dims:  # GFS v16 file
+        if isinstance(dset, xr.DataArray):
+            dset = _dataarray_coards_to_netcdf(dset, lat_name="grid_yt", lon_name="grid_xt")
+        elif isinstance(dset, xr.Dataset):
+            dset = _dataarray_coards_to_netcdf(dset, lat_name="grid_yt", lon_name="grid_xt")
 
     if "south_north" in dset.dims:  # WRF WPS file
         dset = dset.rename(dict(south_north="y", west_east="x"))
-        try:
-            if isinstance(dset, xr.Dataset):
-                if "XLAT_M" in dset.data_vars:
-                    dset["XLAT_M"] = dset.XLAT_M.squeeze()
-                    dset["XLONG_M"] = dset.XLONG_M.squeeze()
-                    dset = dset.set_coords(["XLAT_M", "XLONG_M"])
-                elif "XLAT" in dset.data_vars:
-                    dset["XLAT"] = dset.XLAT.squeeze()
-                    dset["XLONG"] = dset.XLONG.squeeze()
-                    dset = dset.set_coords(["XLAT", "XLONG"])
-            elif isinstance(dset, xr.DataArray):
-                if "XLAT_M" in dset.coords:
-                    dset["XLAT_M"] = dset.XLAT_M.squeeze()
-                    dset["XLONG_M"] = dset.XLONG_M.squeeze()
-                elif "XLAT" in dset.coords:
-                    dset["XLAT"] = dset.XLAT.squeeze()
-                    dset["XLONG"] = dset.XLONG.squeeze()
-            else:
-                raise ValueError
-        except ValueError:
-            print("dset must be an Xarray.DataArray or Xarray.Dataset")
+        if isinstance(dset, xr.Dataset):
+            if "XLAT_M" in dset.data_vars:
+                dset["XLAT_M"] = dset.XLAT_M.squeeze()
+                dset["XLONG_M"] = dset.XLONG_M.squeeze()
+                dset = dset.set_coords(["XLAT_M", "XLONG_M"])
+            elif "XLAT" in dset.data_vars:
+                dset["XLAT"] = dset.XLAT.squeeze()
+                dset["XLONG"] = dset.XLONG.squeeze()
+                dset = dset.set_coords(["XLAT", "XLONG"])
+        elif isinstance(dset, xr.DataArray):
+            if "XLAT_M" in dset.coords:
+                dset["XLAT_M"] = dset.XLAT_M.squeeze()
+                dset["XLONG_M"] = dset.XLONG_M.squeeze()
+            elif "XLAT" in dset.coords:
+                dset["XLAT"] = dset.XLAT.squeeze()
+                dset["XLONG"] = dset.XLONG.squeeze()
 
     # Rename lat/lon coordinates to 'latitude'/'longitude'
     dset = _rename_to_monet_latlon(dset)  # common cases
@@ -145,15 +136,10 @@ def _dataset_to_monet(
     if latlon2d is None:
         latlon2d = dset["latitude"].ndim >= 2
     if not latlon2d:
-        try:
-            if isinstance(dset, xr.DataArray):
-                dset = _dataarray_coards_to_netcdf(dset, lat_name="latitude", lon_name="longitude")
-            elif isinstance(dset, xr.Dataset):
-                dset = _coards_to_netcdf(dset, lat_name="latitude", lon_name="longitude")
-            else:
-                raise ValueError
-        except ValueError:
-            print("dset must be an Xarray.DataArray or Xarray.Dataset")
+        if isinstance(dset, xr.DataArray):
+            dset = _dataarray_coards_to_netcdf(dset, lat_name="latitude", lon_name="longitude")
+        elif isinstance(dset, xr.Dataset):
+            dset = _coards_to_netcdf(dset, lat_name="latitude", lon_name="longitude")
 
     return dset
 

--- a/monet/monet_accessor.py
+++ b/monet/monet_accessor.py
@@ -66,7 +66,7 @@ def _dataset_to_monet(
     dset,
     lat_name="latitude",
     lon_name="longitude",
-    latlon2d=False,
+    latlon2d=None,
 ):
     """Rename xarray DataArray or Dataset coordinate variables for use with monet functions,
     returning a new xarray object.
@@ -79,8 +79,9 @@ def _dataset_to_monet(
         Name of the latitude array.
     lon_name : str
         Name of the longitude array.
-    latlon2d : bool
+    latlon2d : bool, optional
         Whether the latitude and longitude data is two-dimensional.
+        If unset, guess based on dim count.
     """
 
     if "grid_xt" in dset.dims:
@@ -128,10 +129,9 @@ def _dataset_to_monet(
 
     else:
         dset = _rename_to_monet_latlon(dset)
-        latlon2d = True
-        if len(dset[lat_name].shape) < 2:
-            latlon2d = False
-        if latlon2d is False:
+        if latlon2d is None:
+            latlon2d = dset[lat_name].ndim >= 2
+        if not latlon2d:
             try:
                 if isinstance(dset, xr.DataArray):
                     dset = _dataarray_coards_to_netcdf(dset, lat_name=lat_name, lon_name=lon_name)

--- a/monet/util/combinetool.py
+++ b/monet/util/combinetool.py
@@ -71,7 +71,7 @@ def combine_da_to_da(source, target, *, merge=True, interp_time=False, **kwargs)
     ----------
     source : xarray.DataArray or xarray.Dataset
         Gridded data.
-    target : xarray.DataArray
+    target : xarray.DataArray or xarray.Dataset
         Point observations.
     merge : bool
         If false, only return the interpolated source data.
@@ -87,13 +87,14 @@ def combine_da_to_da(source, target, *, merge=True, interp_time=False, **kwargs)
     """
     from ..monet_accessor import _dataset_to_monet
 
-    target_fixed = _dataset_to_monet(target)
-    source_fixed = _dataset_to_monet(source)
-    output = target_fixed.monet.remap_nearest(source_fixed, **kwargs)
+    output = target.monet.remap_nearest(source, **kwargs)
+
     if interp_time:
         output = output.interp(time=target.time)
+
     if merge:
-        output = xr.merge([target_fixed, output])
+        output = xr.merge([_dataset_to_monet(target), output])
+
     return output
 
 

--- a/tests/test_remap.py
+++ b/tests/test_remap.py
@@ -105,12 +105,10 @@ def test_combine_da_da():
     assert float(new.longitude.max()) == pytest.approx(0.9)
     assert float(new.latitude.min()) == pytest.approx(0.1)
     assert float(new.latitude.max()) == pytest.approx(0.9)
-    assert (obs.longitude.values == x).all(), "preserved"
-    assert (new.latitude.isel(x=0).values == obs.latitude.values).all()
 
-    # FIXME
-    assert not (new.longitude.isel(y=0).values == obs.longitude.values).all()
-    assert (new.longitude.isel(y=0).values == x_).all()
+    assert (obs.longitude.values == x).all(), "preserved"
+    assert (new.latitude.isel(x=0).values == obs.latitude.values).all(), "same as target"
+    assert (new.longitude.isel(y=0).values == obs.longitude.values).all(), "same as target"
 
     # Use orthogonal selection to get track
     a = new.data.values[:, new.y, new.x]

--- a/tests/test_remap.py
+++ b/tests/test_remap.py
@@ -90,6 +90,11 @@ def test_combine_da_da():
         },
     )
 
+    # Longitude normalization introduces floating point error
+    x_ = (x + 180) % 360 - 180
+    assert not (x_ == x).any()
+    assert np.abs(x_ - x).max() < 5e-14
+
     # Combine (find closest model grid cell to each obs point)
     # NOTE: to use `merge`, must have matching `level` dims
     new = combine_da_to_da(model, obs, merge=False, interp_time=False)
@@ -100,8 +105,12 @@ def test_combine_da_da():
     assert float(new.longitude.max()) == pytest.approx(0.9)
     assert float(new.latitude.min()) == pytest.approx(0.1)
     assert float(new.latitude.max()) == pytest.approx(0.9)
+    assert (obs.longitude.values == x).all(), "preserved"
     assert (new.latitude.isel(x=0).values == obs.latitude.values).all()
-    assert np.allclose(new.longitude.isel(y=0).values, obs.longitude.values)
+
+    # FIXME
+    assert not (new.longitude.isel(y=0).values == obs.longitude.values).all()
+    assert (new.longitude.isel(y=0).values == x_).all()
 
     # Use orthogonal selection to get track
     a = new.data.values[:, new.y, new.x]


### PR DESCRIPTION
The longitude wrapping/normalization can introduce small floating point errors into longitude coordinates. For example:
```python
>>> (120.711744 + 180) % 360 - 180
120.71174400000001
```

In some situations (no renames), `_dataset_to_monet` was doing this in place. That should now not happen. Additionally, currently I have it set to compute if lon normalization is necessary (min/max) and skip it otherwise, which seems advantageous.

```ipython
In [35]: a = np.random.rand(int(1e7))

In [36]: %timeit (a.min(), a.max())
10.8 ms ± 60.7 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [37]: %timeit (a + 180) % 360 - 180
296 ms ± 3.08 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

cc: @rschwant @bbakernoaa 