### PR TITLE
Address a few warnings

### DIFF
--- a/monet/monet_accessor.py
+++ b/monet/monet_accessor.py
@@ -188,21 +188,19 @@ def _coards_to_netcdf(dset, lat_name="lat", lon_name="lon"):
     lon_name : str
         Name of the longitude array.
     """
-    from numpy import arange, meshgrid
+    from numpy import meshgrid
 
     lon = dset[lon_name]
     lat = dset[lat_name]
     lons, lats = meshgrid(lon, lat)
-    x = arange(len(lon))
-    y = arange(len(lat))
     for name, dim in {lon_name: "x", lat_name: "y"}.items():
         if name in dset.dims:
             dset = dset.swap_dims({name: dim})
     dset = dset.drop_vars([lon_name, lat_name])
     dset.coords["longitude"] = (("y", "x"), lons)
     dset.coords["latitude"] = (("y", "x"), lats)
-    dset["x"] = x
-    dset["y"] = y
+    dset["x"] = pd.RangeIndex(len(lon))
+    dset["y"] = pd.RangeIndex(len(lat))
     dset = dset.set_coords(["latitude", "longitude"])
     return dset
 
@@ -220,21 +218,19 @@ def _dataarray_coards_to_netcdf(da, lat_name="lat", lon_name="lon"):
     lon_name : str
         Name of the longitude array.
     """
-    from numpy import arange, meshgrid
+    from numpy import meshgrid
 
     lon = da[lon_name]
     lat = da[lat_name]
     lons, lats = meshgrid(lon, lat)
-    x = arange(len(lon))
-    y = arange(len(lat))
     for name, dim in {lon_name: "x", lat_name: "y"}.items():
         if name in da.dims:
             da = da.swap_dims({name: dim})
     da = da.drop_vars([lon_name, lat_name])
     da.coords["latitude"] = (("y", "x"), lats)
     da.coords["longitude"] = (("y", "x"), lons)
-    da["x"] = x
-    da["y"] = y
+    da["x"] = pd.RangeIndex(len(lon))
+    da["y"] = pd.RangeIndex(len(lat))
     return da
 
 

--- a/monet/monet_accessor.py
+++ b/monet/monet_accessor.py
@@ -207,14 +207,14 @@ def _coards_to_netcdf(dset, lat_name="lat", lon_name="lon"):
     return dset
 
 
-def _dataarray_coards_to_netcdf(dset, lat_name="lat", lon_name="lon"):
+def _dataarray_coards_to_netcdf(da, lat_name="lat", lon_name="lon"):
     """Convert 1-D lat/lon coords to x/y convention, with
     lat/lon as 2-D variables with (y, x) dimensions,
     returning a new xarray object.
 
     Parameters
     ----------
-    dset : xarray.DataArray
+    da : xarray.DataArray
     lat_name : str
         Name of the latitude array.
     lon_name : str
@@ -222,17 +222,20 @@ def _dataarray_coards_to_netcdf(dset, lat_name="lat", lon_name="lon"):
     """
     from numpy import arange, meshgrid
 
-    lon = dset[lon_name]
-    lat = dset[lat_name]
+    lon = da[lon_name]
+    lat = da[lat_name]
     lons, lats = meshgrid(lon, lat)
     x = arange(len(lon))
     y = arange(len(lat))
-    dset = dset.rename({lon_name: "x", lat_name: "y"})
-    dset.coords["latitude"] = (("y", "x"), lats)
-    dset.coords["longitude"] = (("y", "x"), lons)
-    dset["x"] = x
-    dset["y"] = y
-    return dset
+    for name, dim in {lon_name: "x", lat_name: "y"}.items():
+        if name in da.dims:
+            da = da.swap_dims({name: dim})
+    da = da.drop_vars([lon_name, lat_name])
+    da.coords["latitude"] = (("y", "x"), lats)
+    da.coords["longitude"] = (("y", "x"), lons)
+    da["x"] = x
+    da["y"] = y
+    return da
 
 
 @pd.api.extensions.register_dataframe_accessor("monet")

--- a/monet/monet_accessor.py
+++ b/monet/monet_accessor.py
@@ -195,7 +195,10 @@ def _coards_to_netcdf(dset, lat_name="lat", lon_name="lon"):
     lons, lats = meshgrid(lon, lat)
     x = arange(len(lon))
     y = arange(len(lat))
-    dset = dset.rename({lon_name: "x", lat_name: "y"})
+    for name, dim in {lon_name: "x", lat_name: "y"}.items():
+        if name in dset.dims:
+            dset = dset.swap_dims({name: dim})
+    dset = dset.drop_vars([lon_name, lat_name])
     dset.coords["longitude"] = (("y", "x"), lons)
     dset.coords["latitude"] = (("y", "x"), lats)
     dset["x"] = x

--- a/tests/test_coards.py
+++ b/tests/test_coards.py
@@ -66,7 +66,10 @@ def test_ds_coards_conv(lat_lon_dims, time):
         expected_indexes = ["time"] + expected_indexes
 
     assert ds["lat"].ndim == ds["lon"].ndim == 1
-    assert tuple(ds.dims) == expected_ds_dims
+    try:
+        assert tuple(ds.dims) == expected_ds_dims
+    except AssertionError:
+        assert set(ds.dims) == set(expected_ds_dims)
     if lat_lon_dims:
         assert not {"x", "y"} <= ds.variables.keys()
     assert set(ds.coords) == expected_ds_coords
@@ -74,7 +77,10 @@ def test_ds_coards_conv(lat_lon_dims, time):
     ds2 = _coards_to_netcdf(ds)
 
     # x/y dims
-    assert tuple(ds2.dims) == expected_out_dims
+    try:
+        assert tuple(ds2.dims) == expected_out_dims
+    except AssertionError:
+        assert set(ds2.dims) == set(expected_out_dims)
 
     # lat/lon name normalization
     # 2-D lat/lon coords

--- a/tests/test_coards.py
+++ b/tests/test_coards.py
@@ -1,0 +1,142 @@
+import numpy as np
+import pytest
+import xarray as xr
+
+from monet.monet_accessor import _coards_to_netcdf, _dataarray_coards_to_netcdf
+
+lonmin, latmin, lonmax, latmax = [0, 0, 10, 10]
+
+
+def make_ds(*, nx=8, ny=5, lat_lon_dims=True, time=False):
+    data = np.arange(nx * ny).reshape((ny, nx))
+    assert data.flags["C_CONTIGUOUS"], "xESMF wants this"
+
+    if lat_lon_dims:
+        lat_dim, lon_dim = "lat", "lon"
+    else:
+        lat_dim, lon_dim = "y", "x"
+    dims = (lat_dim, lon_dim)
+    coords = {
+        "lat": (lat_dim, np.linspace(latmin, latmax, ny)),
+        "lon": (lon_dim, np.linspace(lonmin, lonmax, nx)),
+    }
+
+    if time:
+        time_coord = np.arange(2)
+        data = np.stack([data, data + 100], axis=0)
+        dims = ("time",) + dims
+        coords["time"] = ("time", time_coord)
+
+    return xr.Dataset(
+        data_vars={"data": (dims, data)},
+        coords=coords,
+    )
+
+
+@pytest.mark.parametrize(
+    "lat_lon_dims",
+    [
+        pytest.param(True, id="lat-lon-dims"),
+        pytest.param(False, id="x-y-dims"),
+    ],
+)
+@pytest.mark.parametrize(
+    "time",
+    [
+        pytest.param(False, id="no-time"),
+        pytest.param(True, id="with-time"),
+    ],
+)
+def test_ds_coards_conv(lat_lon_dims, time):
+    ds = make_ds(lat_lon_dims=lat_lon_dims, time=time)
+
+    if lat_lon_dims:
+        expected_ds_dims = ("lat", "lon")
+    else:
+        expected_ds_dims = ("y", "x")
+    expected_ds_coords = {"lat", "lon"}
+    expected_out_dims = ("y", "x")
+    expected_out_coords = {"latitude", "longitude", "x", "y"}
+    expected_indexes = ["x", "y"]
+    if time:
+        expected_ds_dims = ("time",) + expected_ds_dims
+        expected_ds_coords = {"time"} | expected_ds_coords
+        expected_out_dims = ("time",) + expected_out_dims
+        expected_out_coords = {"time"} | expected_out_coords
+        expected_indexes = ["time"] + expected_indexes
+
+    assert ds["lat"].ndim == ds["lon"].ndim == 1
+    assert tuple(ds.dims) == expected_ds_dims
+    if lat_lon_dims:
+        assert not {"x", "y"} <= ds.variables.keys()
+    assert set(ds.coords) == expected_ds_coords
+
+    ds2 = _coards_to_netcdf(ds)
+
+    # x/y dims
+    assert tuple(ds2.dims) == expected_out_dims
+
+    # lat/lon name normalization
+    assert {"latitude", "longitude"} <= ds2.variables.keys()
+    assert set(ds2.coords) == expected_out_coords
+
+    # 2-D lat/lon coords
+    assert ds2["latitude"].ndim == ds2["longitude"].ndim == 2
+    assert set(ds2.coords) == expected_out_coords
+
+    # correct lat/lon values after meshgrid expansion
+    assert (ds2["latitude"].values == ds["lat"].values[:, np.newaxis]).all()
+    assert (ds2["longitude"].values == ds["lon"].values[np.newaxis, :]).all()
+
+    # data values preserved
+    np.testing.assert_array_equal(ds2["data"].values, ds["data"].values)
+
+    # index set for x and y
+    assert list(ds2.indexes) == expected_indexes
+
+
+@pytest.mark.parametrize(
+    "lat_lon_dims",
+    [
+        pytest.param(True, id="lat-lon-dims"),
+        pytest.param(False, id="x-y-dims"),
+    ],
+)
+@pytest.mark.parametrize(
+    "time",
+    [
+        pytest.param(False, id="no-time"),
+        pytest.param(True, id="with-time"),
+    ],
+)
+def test_da_coards_conv(lat_lon_dims, time):
+    da = make_ds(lat_lon_dims=lat_lon_dims, time=time)["data"]
+    da2 = _dataarray_coards_to_netcdf(da)
+
+    expected_dims = ("y", "x")
+    expected_coords = {"latitude", "longitude", "x", "y"}
+    expected_indexes = ["x", "y"]
+    if time:
+        expected_dims = ("time",) + expected_dims
+        expected_coords = {"time"} | expected_coords
+        expected_indexes = ["time"] + expected_indexes
+
+    # x/y dims
+    assert da2.dims == expected_dims
+
+    # lat/lon name normalization
+    assert {"latitude", "longitude"} <= da2.coords.keys()
+
+    # 2-D lat/lon coords
+    assert set(da2.coords) == expected_coords
+    assert da2["latitude"].ndim == da2["longitude"].ndim == 2
+
+    # correct lat/lon values after meshgrid expansion
+    assert (da2["latitude"].values == da["lat"].values[:, np.newaxis]).all()
+    assert (da2["longitude"].values == da["lon"].values[np.newaxis, :]).all()
+
+    # data values preserved
+    np.testing.assert_array_equal(da2.values, da.values)
+
+    # index set for x and y
+    assert list(da2.indexes) == expected_indexes

--- a/tests/test_coards.py
+++ b/tests/test_coards.py
@@ -77,9 +77,6 @@ def test_ds_coards_conv(lat_lon_dims, time):
     assert tuple(ds2.dims) == expected_out_dims
 
     # lat/lon name normalization
-    assert {"latitude", "longitude"} <= ds2.variables.keys()
-    assert set(ds2.coords) == expected_out_coords
-
     # 2-D lat/lon coords
     assert ds2["latitude"].ndim == ds2["longitude"].ndim == 2
     assert set(ds2.coords) == expected_out_coords
@@ -112,6 +109,7 @@ def test_ds_coards_conv(lat_lon_dims, time):
 def test_da_coards_conv(lat_lon_dims, time):
     da = make_ds(lat_lon_dims=lat_lon_dims, time=time)["data"]
     da2 = _dataarray_coards_to_netcdf(da)
+    assert isinstance(da2, xr.DataArray)
 
     expected_dims = ("y", "x")
     expected_coords = {"latitude", "longitude", "x", "y"}
@@ -125,8 +123,6 @@ def test_da_coards_conv(lat_lon_dims, time):
     assert da2.dims == expected_dims
 
     # lat/lon name normalization
-    assert {"latitude", "longitude"} <= da2.coords.keys()
-
     # 2-D lat/lon coords
     assert set(da2.coords) == expected_coords
     assert da2["latitude"].ndim == da2["longitude"].ndim == 2

--- a/tests/test_remap.py
+++ b/tests/test_remap.py
@@ -100,7 +100,7 @@ def test_combine_da_da():
     new = combine_da_to_da(model, obs, merge=False, interp_time=False)
 
     # Check
-    assert new.dims == {"z": 5, "y": n, "x": n}
+    assert new.sizes == {"z": 5, "y": n, "x": n}
     assert float(new.longitude.min()) == pytest.approx(0.1)
     assert float(new.longitude.max()) == pytest.approx(0.9)
     assert float(new.latitude.min()) == pytest.approx(0.1)
@@ -112,6 +112,6 @@ def test_combine_da_da():
 
     # Use orthogonal selection to get track
     a = new.data.values[:, new.y, new.x]
-    assert a.shape == (model.dims["z"], n), "model levels but obs grid points"
+    assert a.shape == (model.sizes["z"], n), "model levels but obs grid points"
     assert (np.diff(a.mean(axis=0)) >= 0).all(), "obs profile goes S"
     assert np.isclose(np.diff(a.mean(axis=1)), 1, atol=1e-15, rtol=0).all(), "obs profile goes U"


### PR DESCRIPTION
Replacement for #155. Addresses these warnings:

```
tests/test_remap.py::test_combine_da_da
  /mnt/c/Users/zmoon/git/monet/monet/monet_accessor.py:198: UserWarning: rename 'longitude' to 'x' does not create an index anymore. Try using swap_dims instead or use set_index after rename to create an indexed coordinate.
    dset = dset.rename({lon_name: "x", lat_name: "y"})

tests/test_remap.py::test_combine_da_da
  /mnt/c/Users/zmoon/git/monet/monet/monet_accessor.py:198: UserWarning: rename 'latitude' to 'y' does not create an index anymore. Try using swap_dims instead or use set_index after rename to create an indexed coordinate.
    dset = dset.rename({lon_name: "x", lat_name: "y"})

tests/test_remap.py::test_combine_da_da
  <frozen _collections_abc>:822: FutureWarning: The return type of `Dataset.dims` will be changed to return a set of dimension names in future, in order to be more consistent with `DataArray.dims`. To access a mapping from dimension names to lengths, please use `Dataset.sizes`.

tests/test_remap.py::test_combine_da_da
  <frozen _collections_abc>:883: FutureWarning: The return type of `Dataset.dims` will be changed to return a set of dimension names in future, in order to be more consistent with `DataArray.dims`. To access a mapping from dimension names to lengths, please use `Dataset.sizes`.

tests/test_remap.py::test_combine_da_da
  /mnt/c/Users/zmoon/git/monet/tests/test_remap.py:115: FutureWarning: The return type of `Dataset.dims` will be changed to return a set of dimension names in future, in order to be more consistent with `DataArray.dims`. To access a mapping from dimension names to lengths, please use `Dataset.sizes`.
    assert a.shape == (model.dims["z"], n), "model levels but obs grid points"
```